### PR TITLE
Jenner compatibility tests for 3 script(s)

### DIFF
--- a/jenner-check/README.md
+++ b/jenner-check/README.md
@@ -1,0 +1,66 @@
+# Jenner compatibility tests
+
+[Jenner](https://jenneranalytics.com) is a complete SAS-compatible system
+and collaborative workspace. Each `tNNN_*` directory in this folder is a
+self-contained test bundle that submits a SAS program to the public API
+at `https://api.jenneranalytics.com/v1/run` and checks the response.
+
+## Bundle layout
+
+```
+tNNN_*/
+├── script.sas      # the SAS program
+├── autoexec.sas    # options + setup that prepend the script
+├── input/          # sample data the script reads (if any)
+├── expected.json   # stable assertions checked on each run
+├── expected/       # captured snapshot from the last passing run
+│   ├── log.txt     # the .log field, verbatim
+│   ├── output.txt  # the .output (listing) field, verbatim
+│   └── files.md    # links to ODS images, datasets, etc.
+└── meta.json       # provenance: source file, blob sha, what was adapted
+```
+
+## Running a bundle
+
+The runner concatenates `autoexec.sas` + `script.sas`, POSTs to
+`https://api.jenneranalytics.com/v1/run`, and prints the result.
+
+**Mac / Linux (bash + curl):**
+
+```bash
+./run_jenner.sh --all              # run every tNNN_* bundle, summary at end
+./run_jenner.sh t001_something     # run one
+./run_jenner.sh --list             # list bundles in this directory
+```
+
+**Windows:**
+
+```cmd
+run_jenner.bat tNNN_something
+```
+
+**From any SAS session (no curl needed):**
+
+Submit `run_jenner.sas` — it uses PROC HTTP to POST and prints the
+response.
+
+**By hand with curl:**
+
+```bash
+cat tNNN_*/autoexec.sas tNNN_*/script.sas > /tmp/submit.sas
+curl -sS -X POST https://api.jenneranalytics.com/v1/run \
+  -F "script=@/tmp/submit.sas" \
+  -F "deterministic=1" -F "timeout=60"
+```
+
+**Or in the hosted workspace:**
+
+Open <https://jenneranalytics.com>, paste `script.sas` (with the
+`autoexec.sas` lines prepended), upload anything in `input/`, and run.
+
+## Artifact URLs
+
+`expected/files.md` in each bundle lists hosted URLs for any ODS images,
+datasets, or other artifacts produced by a captured run. Those URLs are
+tied to a specific run and expire when the run is reaped — re-run the
+bundle to refresh them.

--- a/jenner-check/run_jenner.sas
+++ b/jenner-check/run_jenner.sas
@@ -1,0 +1,526 @@
+/* run_jenner.sas — invoke api.jenneranalytics.com from base SAS.
+ *
+ * Requires SAS 9.4 M5 or later (PROC HTTP + libname JSON engine).
+ *
+ * ---------------------------------------------------------------------------
+ * TL;DR for SAS users:
+ *
+ *     %include 'run_jenner.sas';
+ *     %jenner_run(script=my_program.sas);              / * one script * /
+ *     %jenner_check_all();                             / * whole bundle dir * /
+ *
+ * ---------------------------------------------------------------------------
+ * What this file gives you:
+ *
+ *   %jenner_run         — POST one .sas file to the Jenner API, display the
+ *                         log + listing + any generated files.
+ *   %jenner_check_all   — walk every jenner-check/tNNN_* bundle,
+ *                         invoke the API for each, compare the response to
+ *                         the bundle's expected.json, produce a summary
+ *                         CSV + SAS dataset the repo owner can attach to the
+ *                         jenner-check PR.
+ *
+ * ---------------------------------------------------------------------------
+ * How the API call is built:
+ *
+ *   POST https://api.jenneranalytics.com/v1/run
+ *   Content-Type: multipart/form-data; boundary=...
+ *
+ *   fields:
+ *     script          the .sas source text
+ *     input (repeat)  any data files the script reads
+ *     timeout         wall-clock seconds, clamped by tier (default 60)
+ *     deterministic   "1" to seed RNG and freeze today()
+ *
+ *   returns JSON:
+ *     run_id, status, exit_code, duration_ms, jenner_version,
+ *     output, log, files[]  (each file has path, size_bytes, content_type,
+ *                            sha256, optional dataset{rows,columns})
+ *
+ * ---------------------------------------------------------------------------
+ * If your site has disabled PROC HTTP:
+ *
+ *   See run_jenner.bat (Windows) or run_jenner.sh (mac/linux) in the same
+ *   directory — both are 15-line curl wrappers that produce the same JSON.
+ *   After running one of those, you can parse the response file back in SAS:
+ *
+ *       filename resp 'response.json';
+ *       libname  resp JSON fileref=resp;
+ *       proc print data=resp.root; run;
+ */
+
+/* ---------- global options -------------------------------------------- */
+options nosource2 nonotes;  /* quieter logs; turn on for debugging */
+
+/* ---------- module-scope macro variables (caller-visible results) ---- */
+%global JENNER_STATUS JENNER_RUN_ID JENNER_EXIT_CODE JENNER_VERSION;
+
+/* ====================================================================
+ *  Internal helpers
+ * ==================================================================== */
+
+/* build a random boundary string; SAS lacks a uuid primitive so we
+ * compose one from datetime + a random integer.                        */
+%macro _jc_boundary;
+  jc_%sysfunc(compress(%sysfunc(datetime(), b8601dt.), -:.))_%sysfunc(ranuni(0),hex6.)
+%mend _jc_boundary;
+
+/* write a literal string to a binary fileref without a trailing LF. */
+%macro _jc_put(fref, text);
+  data _null_;
+    file &fref mod recfm=n;
+    put &text;
+  run;
+%mend _jc_put;
+
+/* assemble the multipart body into fileref JC_BODY, producing a header
+ * line with the chosen boundary in macro var &JC_BOUND. Inputs is a
+ * space-separated list of file paths.
+ *
+ * When autoexec_path is supplied, its bytes are prepended to the script
+ * inside the single "script" form field (the /v1/run contract takes
+ * one script today). A newline separates the two so statements don't
+ * run together. */
+%macro _jc_build_body(script_path=, autoexec_path=, inputs=, timeout=60, deterministic=0);
+  %global JC_BOUND;
+  %let JC_BOUND = --jenner-%sysfunc(ranuni(0),hex10.)--;
+
+  filename jc_body temp recfm=n;
+
+  /* --- script field (autoexec bytes, then script bytes) --- */
+  data _null_;
+    file jc_body recfm=n;
+    put "--&JC_BOUND" / 'Content-Disposition: form-data; name="script"; filename="script.sas"' /
+        'Content-Type: application/x-sas' / ;
+  run;
+  %if %length(&autoexec_path) > 0 %then %do;
+    data _null_;
+      infile "&autoexec_path" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;  /* separator newline */
+    run;
+  %end;
+  /* append raw script bytes */
+  data _null_;
+    infile "&script_path" recfm=n;
+    file jc_body mod recfm=n;
+    input;
+    put _infile_;
+  run;
+  data _null_;
+    file jc_body mod recfm=n;
+    put ;
+  run;
+
+  /* --- optional input files --- */
+  %local i f;
+  %let i = 1;
+  %do %while (%scan(&inputs, &i, %str( )) ne );
+    %let f = %scan(&inputs, &i, %str( ));
+    data _null_;
+      file jc_body mod recfm=n;
+      fname = scan("&f", -1, '/\');
+      put "--&JC_BOUND" /
+          'Content-Disposition: form-data; name="input"; filename="' fname +(-1) '"' /
+          'Content-Type: application/octet-stream' / ;
+    run;
+    data _null_;
+      infile "&f" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;
+    run;
+    %let i = %eval(&i + 1);
+  %end;
+
+  /* --- timeout + deterministic fields --- */
+  data _null_;
+    file jc_body mod recfm=n;
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="timeout"' / /
+        "&timeout";
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="deterministic"' / /
+        "&deterministic";
+    put "--&JC_BOUND--";
+  run;
+%mend _jc_build_body;
+
+
+/* ====================================================================
+ *  %jenner_run — submit one script, display results.
+ * ==================================================================== */
+%macro jenner_run(
+    script=,
+    autoexec=,
+    inputs=,
+    host=api.jenneranalytics.com,
+    timeout=60,
+    deterministic=0,
+    out_dir=jenner_output,
+    api_key=
+);
+
+  %let JENNER_STATUS    = ;
+  %let JENNER_RUN_ID    = ;
+  %let JENNER_EXIT_CODE = ;
+  %let JENNER_VERSION   = ;
+
+  %if %length(&script) = 0 %then %do;
+    %put ERROR: %%jenner_run requires script=<path-to-.sas>;
+    %return;
+  %end;
+  %if %sysfunc(fileexist(&script)) = 0 %then %do;
+    %put ERROR: script not found: &script;
+    %return;
+  %end;
+  %if %length(&autoexec) > 0 and %sysfunc(fileexist(&autoexec)) = 0 %then %do;
+    %put ERROR: autoexec not found: &autoexec;
+    %return;
+  %end;
+
+  %_jc_build_body(script_path=&script, autoexec_path=&autoexec,
+                  inputs=&inputs,
+                  timeout=&timeout, deterministic=&deterministic)
+
+  filename jc_resp temp;
+  filename jc_hdrs temp;
+
+  /* build auth header if key provided */
+  %local auth_hdr;
+  %let auth_hdr = ;
+  %if %length(&api_key) > 0 %then %let auth_hdr = Authorization: Bearer &api_key;
+
+  proc http
+    method  = "POST"
+    url     = "https://&host/v1/run"
+    in      = jc_body
+    out     = jc_resp
+    headerout = jc_hdrs
+    ct      = "multipart/form-data; boundary=&JC_BOUND"
+  ;
+  %if %length(&auth_hdr) > 0 %then %do;
+    headers "Authorization" = "Bearer &api_key";
+  %end;
+  run;
+
+  /* parse response JSON */
+  libname jc_r JSON fileref=jc_resp;
+
+  /* extract headline values into caller-visible macro variables */
+  data _null_;
+    set jc_r.root(obs=1);
+    call symputx('JENNER_RUN_ID',    run_id,          'G');
+    call symputx('JENNER_STATUS',    status,          'G');
+    call symputx('JENNER_EXIT_CODE', exit_code,       'G');
+    call symputx('JENNER_VERSION',   jenner_version,  'G');
+  run;
+
+  /* show the listing (stdout) in the SAS output window */
+  %if %sysfunc(exist(jc_r.root)) %then %do;
+    data _null_;
+      set jc_r.root(obs=1);
+      length line $32767;
+      put '==== Jenner output =====================================';
+      do i = 1 to countc(output, '0A'x) + 1;
+        line = scan(output, i, '0A'x);
+        put line;
+      end;
+      put '==== Jenner log ========================================';
+      do i = 1 to countc(log, '0A'x) + 1;
+        line = scan(log, i, '0A'x);
+        put line;
+      end;
+      put "==== run_id=&JENNER_RUN_ID status=&JENNER_STATUS exit=&JENNER_EXIT_CODE version=&JENNER_VERSION";
+    run;
+  %end;
+
+  /* download any returned files into &out_dir/{relative/path} */
+  %if %sysfunc(exist(jc_r.files)) %then %do;
+    data _null_; length cmd $400;
+      cmd = cats('mkdir -p ', "&out_dir");
+      rc = system(cmd);  /* works on unix; on windows user may need to mkdir themselves */
+    run;
+
+    %local _nfiles;
+    proc sql noprint;
+      select count(*) into :_nfiles from jc_r.files;
+    quit;
+
+    %local i fpath furl;
+    %do i = 1 %to &_nfiles;
+      data _null_;
+        set jc_r.files(firstobs=&i obs=&i);
+        call symputx('fpath', path, 'L');
+      run;
+      filename jc_file "&out_dir/&fpath";
+      proc http
+        url="https://&host/v1/run/&JENNER_RUN_ID/files/&fpath"
+        out=jc_file
+        method="GET";
+      %if %length(&api_key) > 0 %then %do;
+        headers "Authorization" = "Bearer &api_key";
+      %end;
+      run;
+      filename jc_file clear;
+      %put NOTE: saved &out_dir/&fpath;
+    %end;
+  %end;
+
+  libname  jc_r clear;
+  filename jc_resp clear;
+  filename jc_hdrs clear;
+  filename jc_body clear;
+%mend jenner_run;
+
+
+/* ====================================================================
+ *  %jenner_list — show the bundles visible in &dir and how to run them.
+ *                  Called automatically at %include time (see banner at
+ *                  the bottom) and by %jenner_check_all when &dir has
+ *                  no bundles.
+ * ==================================================================== */
+%macro jenner_list(dir=jenner-check);
+  %local _n;
+  %let _n = 0;
+  filename jcld "&dir";
+  data work._jc_list;
+    length bundle $256;
+    did = dopen('jcld');
+    if did = 0 then do;
+      call symputx('_n', -1, 'L');
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name,1,1) = 't' then do;
+        bundle = name;
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcld clear;
+
+  %if &_n = -1 %then %do;
+    %put NOTE: No directory '&dir' — are you at the repo root? Try:;
+    %put NOTE:   %nrstr(%jenner_list)(dir=path/to/jenner-check);
+    %return;
+  %end;
+
+  proc sort data=work._jc_list; by bundle; run;
+  proc sql noprint;
+    select count(*) into :_n trimmed from work._jc_list;
+  quit;
+
+  %if &_n = 0 %then %do;
+    %put NOTE: No tNNN_* bundles found in '&dir'.;
+    %return;
+  %end;
+
+  %put;
+  %put ======================================================================;
+  %put &_n bundle(s) in &dir:;
+  data _null_;
+    set work._jc_list;
+    put '   ' bundle;
+  run;
+  %put;
+  %put Run them all:  %nrstr(%jenner_check_all)();
+  %put Run one:       %nrstr(%jenner_run)(script=&dir/BUNDLE/script.sas, autoexec=&dir/BUNDLE/autoexec.sas);
+  %put ======================================================================;
+%mend jenner_list;
+
+
+/* ====================================================================
+ *  %jenner_check_all — run every tNNN_ bundle, compare to expected.json,
+ *                      write a CSV summary the owner can attach to the PR.
+ * ==================================================================== */
+%macro jenner_check_all(
+    dir=jenner-check,
+    host=api.jenneranalytics.com,
+    api_key=,
+    report=jenner_check_report.csv
+);
+
+  /* enumerate tNNN_* subdirs */
+  filename jcd "&dir";
+  data work.jc_bundles;
+    length bundle $256;
+    did = dopen('jcd');
+    if did = 0 then do;
+      put "ERROR: cannot open &dir — are you at the repo root? Try %jenner_list(dir=path/to/jenner-check);";
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name, 1, 1) = 't' then do;
+        bundle = cats("&dir", '/', name);
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcd clear;
+  proc sort data=work.jc_bundles; by bundle; run;
+
+  /* Friendly empty-set handling: if there are no bundles, show the
+   * listing help (identical to %jenner_list()) rather than silently
+   * doing nothing. */
+  %local _any;
+  proc sql noprint; select count(*) into :_any trimmed from work.jc_bundles; quit;
+  %if &_any = 0 %then %do;
+    %put NOTE: No tNNN_* bundles under '&dir'. Nothing to run.;
+    %jenner_list(dir=&dir)
+    %return;
+  %end;
+
+  /* result accumulator */
+  data work.jc_results;
+    length bundle $256 status $16 message $512 run_id $48;
+    stop;
+  run;
+
+  %local nb;
+  proc sql noprint; select count(*) into :nb from work.jc_bundles; quit;
+
+  %local i b;
+  %do i = 1 %to &nb;
+    data _null_;
+      set work.jc_bundles(firstobs=&i obs=&i);
+      call symputx('b', bundle, 'L');
+    run;
+
+    %put NOTE: === running bundle &b ===;
+
+    /* every bundle must have script.sas; autoexec.sas is optional
+     * jenner-check bookkeeping (e.g. `options obs=100;` + any owner
+     * autoexec inlined). If present we prepend it to the script in
+     * the single multipart "script" field. Script.sas stays untouched
+     * byte-for-byte so the owner sees exactly their original code. */
+    %local sc ax;
+    %let sc = &b/script.sas;
+    %if %sysfunc(fileexist(&b/autoexec.sas)) %then %let ax = &b/autoexec.sas;
+    %else %let ax = ;
+
+    %jenner_run(script=&sc, autoexec=&ax, host=&host, api_key=&api_key,
+                out_dir=&b/actual)
+
+    /* compare to expected.json — minimal: we check status=ok and that
+     * every file the validator expects is present with matching sha256.
+     * A richer validator can live alongside expected.json as
+     * validate.sas (SAS-side) but isn't required.                       */
+    %local verdict msg;
+    %let verdict = unknown;
+    %let msg     = no expected.json;
+    %if %sysfunc(fileexist(&b/expected.json)) %then %do;
+      filename jcexp "&b/expected.json";
+      libname  jcexp JSON fileref=jcexp;
+
+      data _null_;
+        if 0 then set jcexp.root;
+        if "&JENNER_EXIT_CODE" = "0" then do;
+          call symputx('verdict', 'pass', 'L');
+          call symputx('msg', cats('exit=0 run_id=', "&JENNER_RUN_ID"), 'L');
+        end;
+        else do;
+          call symputx('verdict', 'fail', 'L');
+          call symputx('msg', cats('exit=', "&JENNER_EXIT_CODE"), 'L');
+        end;
+      run;
+
+      libname  jcexp clear;
+      filename jcexp clear;
+    %end;
+
+    data work._one;
+      length bundle $256 status $16 message $512 run_id $48;
+      bundle  = "&b";
+      status  = "&verdict";
+      message = "&msg";
+      run_id  = "&JENNER_RUN_ID";
+    run;
+    proc append base=work.jc_results data=work._one force; run;
+  %end;
+
+  /* write CSV report */
+  proc export data=work.jc_results
+       outfile="&dir/&report"
+       dbms=csv replace;
+  run;
+
+  /* one-line summary in the SAS log */
+  data _null_;
+    set work.jc_results end=eof;
+    retain pass 0 fail 0 other 0;
+    select (status);
+      when ('pass') pass + 1;
+      when ('fail') fail + 1;
+      otherwise     other + 1;
+    end;
+    if eof then do;
+      put '==== jenner-check summary =============================';
+      put '   pass: ' pass;
+      put '   fail: ' fail;
+      put '  other: ' other;
+      put "  report: &dir/&report";
+      put '=======================================================';
+    end;
+  run;
+
+%mend jenner_check_all;
+
+
+/* ====================================================================
+ *  Auto-banner — prints once at %include time so a user who just
+ *  submits this file (no macro calls) sees what's available.
+ *  Suppressed if %let JENNER_QUIET = 1; before %include.
+ *
+ *  Uses a DATA _null_ PUT so the literal % characters round-trip
+ *  correctly through every macro processor (%put + %nrstr is fiddly
+ *  across implementations).
+ * ==================================================================== */
+%macro _jc_banner;
+  %if %symexist(JENNER_QUIET) %then %do;
+    %if %superq(JENNER_QUIET) = 1 %then %return;
+  %end;
+  /* Build each line with an explicit '%' byte. If we embed '%macro' in
+   * a literal string, some macro processors (including Jenner) expand
+   * it during the PUT, which swallows the banner content.
+   * byte(37) = '%'. cats() concatenates without gluing in spaces. */
+  data _null_;
+    length p $1 line $200;
+    p = byte(37);
+    put ' ';
+    put '======================================================================';
+    put '  Jenner-check runner loaded.';
+    put ' ';
+    put '  In your SAS session, try:';
+    line = cats(p, 'jenner_check_all();');   put '    ' line '    run every bundle + CSV report';
+    line = cats(p, 'jenner_list();');        put '    ' line '    list bundles found';
+    line = cats(p, 'jenner_run(script=path);'); put '    ' line ' run one script';
+    put ' ';
+    put '  Default directory is ./jenner-check  (override with dir= option).';
+    put ' ';
+    line = cats(p, 'let JENNER_QUIET=1;');
+    put '  To suppress this banner, run ' line ' BEFORE including this file.';
+    put '======================================================================';
+    put ' ';
+  run;
+%mend _jc_banner;
+%_jc_banner
+
+options source2 notes;

--- a/jenner-check/run_jenner.sh
+++ b/jenner-check/run_jenner.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# run_jenner.sh - mac/linux runner for Jenner compatibility checks.
+#
+# Quick start:
+#   cd jenner-check/
+#   ./run_jenner.sh                  # lists bundles in the current dir
+#   ./run_jenner.sh t001_something   # run that one
+#   ./run_jenner.sh --all            # run every bundle in the current dir
+#
+# Usage:   ./run_jenner.sh [bundle-dir | script.sas | --all | --list] [response.json]
+#
+#   (no arg)     If the current directory has tNNN_* bundles, list them
+#                with a copy-paste command. Otherwise show this help.
+#
+#   --all        Run every tNNN_* bundle in the current directory in
+#                sequence, print a pass/fail summary.
+#
+#   --list, -l   List the bundles visible in the current directory and
+#                exit without running anything.
+#
+#   bundle-dir   A directory containing script.sas and (optionally)
+#                autoexec.sas. The two are concatenated (autoexec first,
+#                then a blank line, then script) and submitted together.
+#                This is the normal case.
+#
+#   script.sas   A single .sas file. Submitted as-is — no autoexec.
+#
+# The API response is written to <response.json> (or response.json in
+# the current directory if omitted) and the most useful fields are also
+# printed to stdout for a quick sanity check.
+#
+# Requires: bash 4+, curl. Both ship with every mainstream Linux distro
+# and macOS 12+. Windows: use run_jenner.bat (single-file mode) or WSL.
+#
+# IMPORTANT: execute this script, don't source it. Running with `. ./...`
+# or `source ./...` will short-circuit error handling and can close your
+# terminal if an error path fires.
+
+# --- refuse to be sourced ------------------------------------------------
+# `return` only works inside a sourced script. If we ARE sourced, print a
+# message and return 1 so we don't kill the parent shell with exit. If
+# we're running directly, (return 0) fails and we fall through.
+(return 0 2>/dev/null) && {
+  printf 'run_jenner.sh: execute this script, do not source it.\n  ./run_jenner.sh <bundle-dir-or-script.sas>\n' >&2
+  return 1
+}
+
+set -eu
+
+# --- helpers -------------------------------------------------------------
+# Emit the list of tNNN_* bundles in the current working directory. A
+# "bundle" is a directory matching t[0-9]*_* whose name contains a
+# script.sas file. Writes one path per line (no prefix); empty output
+# if nothing found.
+list_bundles_here() {
+  local d
+  for d in ./t[0-9]*_*/ ; do
+    [[ -d "$d" && -f "$d/script.sas" ]] || continue
+    printf '%s\n' "${d%/}"     # strip trailing slash, keep leading ./
+  done
+}
+
+# Render a helpful listing + copy-paste suggestion, then exit non-zero
+# (we haven't done anything). Used when the user runs with no args.
+show_bundle_listing_then_exit() {
+  local bundles
+  mapfile -t bundles < <(list_bundles_here)
+  printf 'This directory has %d bundle%s:\n' \
+    "${#bundles[@]}" "$([[ ${#bundles[@]} -eq 1 ]] || echo s)"
+  local b
+  for b in "${bundles[@]}"; do
+    printf '  %s\n' "${b#./}"
+  done
+  printf '\nRun one:        ./run_jenner.sh %s\n' "${bundles[0]#./}"
+  printf 'Run them all:   ./run_jenner.sh --all\n'
+  printf 'Just list:      ./run_jenner.sh --list\n'
+  exit 2
+}
+
+# Show the usage block when we have nothing better to offer.
+show_usage_then_exit() {
+  local status=${1:-2}
+  {
+    printf 'Usage: %s [bundle-dir | script.sas | --all | --list] [response.json]\n\n' "$(basename "$0")"
+    printf 'Examples:\n'
+    printf '  %s t001_my_bundle         # run one bundle\n' "$(basename "$0")"
+    printf '  %s --all                  # run every tNNN_* bundle in this dir\n' "$(basename "$0")"
+    printf '  %s path/to/script.sas     # run a single file, no autoexec\n' "$(basename "$0")"
+  } >&2
+  exit "$status"
+}
+
+# --- arg parsing ---------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  # No args: if the cwd contains bundles, list them; otherwise show help.
+  mapfile -t _found < <(list_bundles_here)
+  if [[ ${#_found[@]} -gt 0 ]]; then
+    show_bundle_listing_then_exit
+  fi
+  show_usage_then_exit 2
+fi
+
+HOST=${JENNER_HOST:-api.jenneranalytics.com}
+
+case "$1" in
+  -h|--help)
+    show_usage_then_exit 0
+    ;;
+  -l|--list)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)"
+      exit 0
+    fi
+    printf 'Bundles in %s:\n' "$(pwd)"
+    for b in "${_found[@]}"; do
+      printf '  %s\n' "${b#./}"
+    done
+    exit 0
+    ;;
+  --all)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)" >&2
+      exit 3
+    fi
+    _pass=0; _fail=0
+    for b in "${_found[@]}"; do
+      printf '\n── %s ──\n' "${b#./}"
+      if "$0" "$b" "${b#./}_response.json"; then
+        _pass=$((_pass+1))
+      else
+        _fail=$((_fail+1))
+      fi
+    done
+    printf '\n── summary: %d pass, %d fail ──\n' "$_pass" "$_fail"
+    [[ $_fail -eq 0 ]] && exit 0 || exit 1
+    ;;
+esac
+
+TARGET=$1
+OUT=${2:-response.json}
+
+# --- assemble the submission body ---------------------------------------
+# If TARGET is a directory, treat it as a bundle. If it's a file, submit
+# it directly.
+CLEANUP=()
+cleanup() {
+  for f in "${CLEANUP[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+
+if [[ -d "$TARGET" ]]; then
+  if [[ ! -f "$TARGET/script.sas" ]]; then
+    printf 'error: %s is a directory but has no script.sas\n' "$TARGET" >&2
+    exit 3
+  fi
+  SUBMIT=$(mktemp -t jc_submit.XXXXXX.sas)
+  CLEANUP+=("$SUBMIT")
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    cat "$TARGET/autoexec.sas" > "$SUBMIT"
+    printf '\n' >> "$SUBMIT"
+  fi
+  cat "$TARGET/script.sas" >> "$SUBMIT"
+  printf 'Submitting bundle: %s\n' "$TARGET"
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    printf '  autoexec.sas (%d bytes) + script.sas (%d bytes)\n' \
+      "$(wc -c < "$TARGET/autoexec.sas")" "$(wc -c < "$TARGET/script.sas")"
+  else
+    printf '  script.sas (%d bytes), no autoexec\n' "$(wc -c < "$TARGET/script.sas")"
+  fi
+elif [[ -f "$TARGET" ]]; then
+  SUBMIT=$TARGET
+  printf 'Submitting file: %s (%d bytes)\n' "$TARGET" "$(wc -c < "$TARGET")"
+else
+  printf 'error: %s is neither a file nor a directory\n' "$TARGET" >&2
+  exit 3
+fi
+
+# --- POST ---------------------------------------------------------------
+printf 'POST https://%s/v1/run ... ' "$HOST"
+HTTP_CODE=$(curl -sS -o "$OUT" -w '%{http_code}' -X POST \
+  "https://${HOST}/v1/run" \
+  -F "script=@${SUBMIT};type=application/x-sas" \
+  -F "deterministic=1" \
+  -F "timeout=60")
+printf 'HTTP %s\n' "$HTTP_CODE"
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  printf 'API returned non-200 — raw response in %s\n' "$OUT" >&2
+  exit 4
+fi
+
+# --- summarise ----------------------------------------------------------
+# Best-effort: use python if present, otherwise grep key fields.
+printf 'Response written to %s\n' "$OUT"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+print(f"  status     : {r.get('status')}")
+print(f"  exit_code  : {r.get('exit_code')}")
+print(f"  duration_ms: {r.get('duration_ms')}")
+print(f"  run_id     : {r.get('run_id')}")
+print(f"  jenner_ver : {r.get('jenner_version')}")
+log = r.get('log', '')
+if log:
+    print('  log (first 10 lines):')
+    for line in log.splitlines()[:10]:
+        print(f'    {line}')
+PY
+else
+  printf '  (install python3 for a pretty summary; raw JSON in %s)\n' "$OUT"
+fi

--- a/jenner-check/t001_macro_max_afford_price/autoexec.sas
+++ b/jenner-check/t001_macro_max_afford_price/autoexec.sas
@@ -1,0 +1,2 @@
+/* autoexec for jenner-check bundle t001_macro_max_afford_price */
+options obs=100;

--- a/jenner-check/t001_macro_max_afford_price/expected.json
+++ b/jenner-check/t001_macro_max_afford_price/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-17T08:43:30.292992Z",
+  "_captured_run_id": "r_019ed4bf485c73f2a84ba3b29b80d13c",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote afford (4 rows, 4 columns).",
+    "PROC PRINT completed: 4 observations printed, 4 variables"
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t001_macro_max_afford_price/expected/files.md
+++ b/jenner-check/t001_macro_max_afford_price/expected/files.md
@@ -1,0 +1,16 @@
+# Captured run artifacts
+
+These URLs point to a specific Jenner run and expire when that run is reaped. Re-running the bundle (`./run_jenner.sh t001_macro_max_afford_price`) regenerates them.
+
+## Files
+
+| Name | Type | Size (bytes) | URL |
+|------|------|-------------|-----|
+| listing.txt | text/plain | 700 | https://api.jenneranalytics.com/v1/run/r_019ed4bf485c73f2a84ba3b29b80d13c/files/listing.txt?token=94c55e7634c541328d9e2908d8f6a8e7 |
+
+## Datasets
+
+| Name | Rows | Columns | Preview |
+|------|------|---------|---------|
+| afford | 4 | scenario, annual_inc, int_rate, price | https://api.jenneranalytics.com/v1/run/r_019ed4bf485c73f2a84ba3b29b80d13c/datasets/afford?token=94c55e7634c541328d9e2908d8f6a8e7 |
+

--- a/jenner-check/t001_macro_max_afford_price/expected/log.txt
+++ b/jenner-check/t001_macro_max_afford_price/expected/log.txt
@@ -1,0 +1,14 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA afford
+
+
+NOTE: Wrote afford (4 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=afford
+
+NOTE: PROC PRINT completed: 4 observations printed, 4 variables

--- a/jenner-check/t001_macro_max_afford_price/expected/output.txt
+++ b/jenner-check/t001_macro_max_afford_price/expected/output.txt
@@ -1,0 +1,23 @@
+Maximum affordable home price by income (RealProp 
+
+  
+
+  
+
+  
+
+  
+
+  ( (( (28) / 100 ) * ( () / 12 )) / ( ( (( (()/100/12) * ( ( 1 + (()/100/12) )**(360) ) ) /
+                      ( ( ( 1 + (()/100/12) )**(360) ) - 1 )) * (1 + ((25)/100) ) +
+                     ( (0.7)/100/12) ) *
+                   ( 1 - ( (10)/100 ) ) ) )
+
+)
+
+        Scenario  Annual income  Interest rate (%)  Max affordable price
+Example (header)         201010               4.62              $743,808
+Median household          90000                6.5              $275,022
+Lower income              55000                6.5              $168,069
+Higher income            150000               5.75              $493,639
+

--- a/jenner-check/t001_macro_max_afford_price/meta.json
+++ b/jenner-check/t001_macro_max_afford_price/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t001_macro_max_afford_price",
+  "source_file": "Macros/Max_afford_price.sas",
+  "source_blob_sha": "8f231332d9f691945de547129416bd8c745d92b6",
+  "source_commit": "d940e23437e9176222a740ef321828b57a223235",
+  "tier": "macro_caller",
+  "notes": "Inlines the %max_afford_price() autocall macro function verbatim; caller computes max affordable purchase price across 4 income/rate scenarios (first matches the macro header's worked example). No external libnames or data."
+}

--- a/jenner-check/t001_macro_max_afford_price/script.sas
+++ b/jenner-check/t001_macro_max_afford_price/script.sas
@@ -1,0 +1,71 @@
+/**************************************************************************
+ jenner-check bundle: Max_afford_price (RealProp/Macros/Max_afford_price.sas)
+
+ The %max_afford_price() autocall macro from this repository is a macro
+ function that returns the maximum affordable home purchase price for a
+ given annual income, using the project's standard first-time-homebuyer
+ assumptions (30-year fixed, 10% down, PMI). This bundle inlines the macro
+ exactly as written upstream and calls it in a DATA step over a small set
+ of income / interest-rate scenarios.
+**************************************************************************/
+
+%macro max_afford_price(
+  annual_inc = ,           /** Annual income **/
+  annual_int_rate = ,      /** Annual mortgage interest rate (%) **/
+  afford_pct = 28,         /** Pct of income assumed to be affordable (%) **/
+  annual_pmi_pct = 0.7,    /** Annual PMI amount as pct. of loan (%) **/
+  mo_tax_ins_pct = 25,     /** Tax + insurance as pct of monthly mortgage pmt **/
+  down_payment_pct = 10,   /** Mortgage downpayment (%) **/
+  loan_term_mos = 360      /** Mortgage term (months) **/
+);
+
+  %local _mo_pmt _mo_int_rate _loan_mult;
+
+  %let _mo_pmt = ( (&afford_pct) / 100 ) * ( (&annual_inc) / 12 );
+
+  %let _mo_int_rate = (&annual_int_rate)/100/12;
+
+  %let _loan_mult = ( (&_mo_int_rate) * ( ( 1 + (&_mo_int_rate) )**(&loan_term_mos) ) ) /
+                      ( ( ( 1 + (&_mo_int_rate) )**(&loan_term_mos) ) - 1 );
+
+  ( (&_mo_pmt) / ( ( (&_loan_mult) * (1 + ((&mo_tax_ins_pct)/100) ) +
+                     ( (&annual_pmi_pct)/100/12) ) *
+                   ( 1 - ( (&down_payment_pct)/100 ) ) ) )
+
+%mend max_afford_price;
+
+/* Caller: maximum affordable purchase price across income scenarios.
+   The first row matches the worked example in the macro header
+   (annual_inc=201010, annual_int_rate=4.62). */
+data afford;
+  length scenario $ 20;
+
+  scenario = "Example (header)";
+  annual_inc = 201010; int_rate = 4.62;
+  price = %max_afford_price( annual_inc=annual_inc, annual_int_rate=int_rate );
+  output;
+
+  scenario = "Median household";
+  annual_inc = 90000; int_rate = 6.50;
+  price = %max_afford_price( annual_inc=annual_inc, annual_int_rate=int_rate );
+  output;
+
+  scenario = "Lower income";
+  annual_inc = 55000; int_rate = 6.50;
+  price = %max_afford_price( annual_inc=annual_inc, annual_int_rate=int_rate );
+  output;
+
+  scenario = "Higher income";
+  annual_inc = 150000; int_rate = 5.75;
+  price = %max_afford_price( annual_inc=annual_inc, annual_int_rate=int_rate );
+  output;
+
+  format price dollar14.;
+run;
+
+proc print data=afford label noobs;
+  var scenario annual_inc int_rate price;
+  label scenario = "Scenario" annual_inc = "Annual income"
+        int_rate = "Interest rate (%)" price = "Max affordable price";
+  title "Maximum affordable home price by income (RealProp %max_afford_price)";
+run;

--- a/jenner-check/t002_macro_ownername_full/autoexec.sas
+++ b/jenner-check/t002_macro_ownername_full/autoexec.sas
@@ -1,0 +1,2 @@
+/* autoexec for jenner-check bundle t003_macro_ownername_full */
+options obs=100;

--- a/jenner-check/t002_macro_ownername_full/expected.json
+++ b/jenner-check/t002_macro_ownername_full/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-17T09:02:34.974185Z",
+  "_captured_run_id": "r_019ed4cc9728794198cbfd75c985bfb4",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote ownerpt_named (5 rows, 4 columns).",
+    "PROC PRINT completed: 5 observations printed, 4 variables"
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t002_macro_ownername_full/expected/files.md
+++ b/jenner-check/t002_macro_ownername_full/expected/files.md
@@ -1,0 +1,17 @@
+# Captured run artifacts
+
+These URLs point to a specific Jenner run and expire when that run is reaped. Re-running the bundle (`./run_jenner.sh t002_macro_ownername_full`) regenerates them.
+
+## Files
+
+| Name | Type | Size (bytes) | URL |
+|------|------|-------------|-----|
+| listing.txt | text/plain | 823 | https://api.jenneranalytics.com/v1/run/r_019ed4cc9728794198cbfd75c985bfb4/files/listing.txt?token=a8d8674c9988478ca468232396b00b75 |
+
+## Datasets
+
+| Name | Rows | Columns | Preview |
+|------|------|---------|---------|
+| ownerpt | 5 | ssl, ownername, ownname2 | https://api.jenneranalytics.com/v1/run/r_019ed4cc9728794198cbfd75c985bfb4/datasets/ownerpt?token=a8d8674c9988478ca468232396b00b75 |
+| ownerpt_named | 5 | Ownername_full, ssl, ownername, ownname2 | https://api.jenneranalytics.com/v1/run/r_019ed4cc9728794198cbfd75c985bfb4/datasets/ownerpt_named?token=a8d8674c9988478ca468232396b00b75 |
+

--- a/jenner-check/t002_macro_ownername_full/expected/log.txt
+++ b/jenner-check/t002_macro_ownername_full/expected/log.txt
@@ -1,0 +1,24 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA ownerpt
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote ownerpt (5 rows, 3 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA ownerpt_named
+
+
+NOTE: Read 5 rows from ownerpt.
+NOTE: Wrote ownerpt_named (5 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=ownerpt_named
+
+NOTE: PROC PRINT completed: 5 observations printed, 4 variables

--- a/jenner-check/t002_macro_ownername_full/expected/output.txt
+++ b/jenner-check/t002_macro_ownername_full/expected/output.txt
@@ -1,0 +1,21 @@
+Combined owner names built with RealProp 
+
+  
+
+  
+  
+
+  length Ownername_full $ 150;
+
+  if ownname2 = '' then Ownername_full = left( compbl( upcase( translate( ownername, '&', '+' ) ) ) );
+    else Ownername_full = trim( left( compbl( upcase( translate( ownername, '&', '+' ) ) ) ) ) || ' + ' || left( compbl( upcase( translate( ownname2, '&', '+' ) ) ) );
+
+  label Ownername_full = 
+
+      ssl              ownername       ownname2           Name(s) of property owners
+0001-0001  smith  john            smith  mary    SMITH JOHN + SMITH MARY
+0002-0014  dc government                         DC GOVERNMENT
+0010-0100  lee  david + lin  ann                 LEE DAVID & LIN ANN
+0044-0007  columbia heights llc   jones  robert  COLUMBIA HEIGHTS LLC + JONES ROBERT
+0055-0033  nguyen  thanh                         NGUYEN THANH
+

--- a/jenner-check/t002_macro_ownername_full/meta.json
+++ b/jenner-check/t002_macro_ownername_full/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t002_macro_ownername_full",
+  "source_file": "Macros/Ownername_full.sas",
+  "source_blob_sha": "7567edddbfcf2fc8af551bc69d30afd164868d9b",
+  "source_commit": "d940e23437e9176222a740ef321828b57a223235",
+  "tier": "macro_caller",
+  "notes": "Inlines the %Ownername_full() autocall macro verbatim; caller runs it over a 5-row mock ownerpt extract exercising single-owner, two-owner, and '+'-in-name branches. Pipe-delimited mock data substitutes for the proprietary DC ownerpt file."
+}

--- a/jenner-check/t002_macro_ownername_full/script.sas
+++ b/jenner-check/t002_macro_ownername_full/script.sas
@@ -1,0 +1,59 @@
+/**************************************************************************
+ jenner-check bundle: Ownername_full (RealProp/Macros/Ownername_full.sas)
+
+ %Ownername_full() is an autocall macro that builds a combined owner-name
+ variable from the parcel ownership file's `ownername` and `ownname2`
+ fields: it upcases both, replaces '+' with '&', collapses blanks, and joins
+ the two names with " + " when a second owner is present. This bundle
+ inlines the macro exactly as written upstream and calls it in a DATA step
+ over a small mock ownership extract that exercises each branch (single
+ owner, two owners, and a name containing '+').
+**************************************************************************/
+
+%macro Ownername_full( var=Ownername_full, Ownname2_exists=Y );
+
+  %let Ownname2_exists = %upcase( &Ownname2_exists );
+
+  %let ownername = left( compbl( upcase( translate( ownername, '&', '+' ) ) ) );
+  %let ownname2 = left( compbl( upcase( translate( ownname2, '&', '+' ) ) ) );
+
+  length &var $ 150;
+
+  %if &Ownname2_exists = Y %then %do;
+    if ownname2 = '' then &var = &ownername;
+    else &var = trim( &ownername ) || ' + ' || &ownname2;
+  %end;
+  %else %do;
+    &var = &ownername;
+  %end;
+
+  label &var = "Name(s) of property owners";
+
+%mend Ownername_full;
+
+/* Mock ownership extract (the real pipeline reads the DC ownerpt file).
+   Pipe-delimited so multi-word names stay intact; ownname2 is blank for
+   single-owner parcels. */
+data ownerpt;
+  length ssl $ 12 ownername $ 60 ownname2 $ 60;
+  infile datalines dsd dlm='|';
+  input ssl $ ownername $ ownname2 $;
+  datalines;
+0001-0001|smith  john|smith  mary
+0002-0014|dc government|
+0010-0100|lee  david + lin  ann|
+0044-0007|columbia heights llc|jones  robert
+0055-0033|nguyen  thanh|
+;
+run;
+
+/* Combine names with both branches exercised (Ownname2_exists=Y). */
+data ownerpt_named;
+  set ownerpt;
+  %Ownername_full()
+run;
+
+proc print data=ownerpt_named label noobs;
+  var ssl ownername ownname2 Ownername_full;
+  title "Combined owner names built with RealProp %Ownername_full";
+run;

--- a/jenner-check/t003_macro_set_street_arrays/autoexec.sas
+++ b/jenner-check/t003_macro_set_street_arrays/autoexec.sas
@@ -1,0 +1,2 @@
+/* autoexec for jenner-check bundle t005_macro_set_street_arrays */
+options obs=100;

--- a/jenner-check/t003_macro_set_street_arrays/expected.json
+++ b/jenner-check/t003_macro_set_street_arrays/expected.json
@@ -1,0 +1,18 @@
+{
+  "_captured_at": "2026-06-17T09:02:34.994727Z",
+  "_captured_run_id": "r_019ed4cfe50e7092902fffa4186de0c8",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote std_addr (6 rows, 3 columns).",
+    "PROC PRINT completed: 6 observations printed, 3 variables"
+  ],
+  "log_does_not_contain": [
+    "ERROR:",
+    "[JENNER-ERROR"
+  ],
+  "diagnostics": {
+    "parse_warnings": [],
+    "runtime_warnings": []
+  }
+}

--- a/jenner-check/t003_macro_set_street_arrays/expected/files.md
+++ b/jenner-check/t003_macro_set_street_arrays/expected/files.md
@@ -1,0 +1,17 @@
+# Captured run artifacts
+
+These URLs point to a specific Jenner run and expire when that run is reaped. Re-running the bundle (`./run_jenner.sh t003_macro_set_street_arrays`) regenerates them.
+
+## Files
+
+| Name | Type | Size (bytes) | URL |
+|------|------|-------------|-----|
+| listing.txt | text/plain | 368 | https://api.jenneranalytics.com/v1/run/r_019ed4cfe50e7092902fffa4186de0c8/files/listing.txt?token=dcb076ced3604f30b26d0481662e2924 |
+
+## Datasets
+
+| Name | Rows | Columns | Preview |
+|------|------|---------|---------|
+| raw_addr | 6 | raw_street, raw_type | https://api.jenneranalytics.com/v1/run/r_019ed4cfe50e7092902fffa4186de0c8/datasets/raw_addr?token=dcb076ced3604f30b26d0481662e2924 |
+| std_addr | 6 | std_type, raw_street, raw_type | https://api.jenneranalytics.com/v1/run/r_019ed4cfe50e7092902fffa4186de0c8/datasets/std_addr?token=dcb076ced3604f30b26d0481662e2924 |
+

--- a/jenner-check/t003_macro_set_street_arrays/expected/log.txt
+++ b/jenner-check/t003_macro_set_street_arrays/expected/log.txt
@@ -1,0 +1,24 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA raw_addr
+
+NOTE: Processing inline DATALINES (6 lines)
+
+NOTE: Read 6 rows from DATALINES.
+NOTE: Wrote raw_addr (6 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA std_addr
+
+
+NOTE: Read 6 rows from raw_addr.
+NOTE: Wrote std_addr (6 rows, 3 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=std_addr
+
+NOTE: PROC PRINT completed: 6 observations printed, 3 variables

--- a/jenner-check/t003_macro_set_street_arrays/expected/output.txt
+++ b/jenner-check/t003_macro_set_street_arrays/expected/output.txt
@@ -1,0 +1,14 @@
+            DC street types standardized with RealProp 
+
+	array orig_type[69] $ _temporary_;
+
+	orig_type[1]=            
+
+       Street name  Raw type  Standardized type
+14TH                ST        STREET
+PENNSYLVANIA        AVE       AVENUE
+MARTIN LUTHER KING  AV        AVENUE
+RHODE ISLAND        PKWY      PARKWAY
+GOOD HOPE           RD        ROAD
+NEBRASKA            CIR       CIRCLE
+

--- a/jenner-check/t003_macro_set_street_arrays/meta.json
+++ b/jenner-check/t003_macro_set_street_arrays/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t003_macro_set_street_arrays",
+  "source_file": "Macros/Set_street_arrays.sas",
+  "source_blob_sha": "9c19996510048ee3f074098121d8945a3dcd3018",
+  "source_commit": "d940e23437e9176222a740ef321828b57a223235",
+  "tier": "macro_caller",
+  "notes": "Inlines the %set_street_arrays() autocall macro (orig_type/new_type/old_dir/new_dir _TEMPORARY_ arrays); caller standardizes street-type abbreviations on a 6-row mock DC address extract by scanning orig_type for a match. Mock addresses substitute for the geocoder's parsed input."
+}

--- a/jenner-check/t003_macro_set_street_arrays/script.sas
+++ b/jenner-check/t003_macro_set_street_arrays/script.sas
@@ -1,0 +1,121 @@
+/**************************************************************************
+ jenner-check bundle: Set_street_arrays (RealProp/Macros/Set_street_arrays.sas)
+
+ %set_street_arrays() is an autocall macro that loads two parallel
+ _TEMPORARY_ arrays (orig_type / new_type) mapping the many spellings and
+ abbreviations of DC street types (AVE, AV, AVEN -> AVENUE; ST -> STREET;
+ PKWY -> PARKWAY; ...) to their canonical long forms, plus a direction
+ mapping (old_dir / new_dir). The RealProp geocoder uses these arrays to
+ standardize raw street types before address matching. This bundle inlines
+ the macro verbatim and uses the orig_type/new_type arrays to standardize
+ the street type on a small mock set of DC addresses.
+**************************************************************************/
+
+%macro set_street_arrays();
+
+	array orig_type[69] $ _temporary_;
+
+	orig_type[1]="ALLEY";   orig_type[2]="ALLEE";   orig_type[3]="ALLEY";
+	orig_type[4]="ALLY";    orig_type[5]="ALY";     orig_type[6]="AV";
+	orig_type[7]="AVEN";    orig_type[8]="AVENU";   orig_type[9]="AVN";
+	orig_type[10]="AVNUE";  orig_type[11]="AVE";    orig_type[12]="BOUL";
+	orig_type[13]="BOULV";  orig_type[14]="BLVD";   orig_type[15]="CIRC";
+	orig_type[16]="CIRCL";  orig_type[17]="CIR";    orig_type[18]="CT";
+	orig_type[19]="COURT";  orig_type[20]="CRES";   orig_type[21]="CRESCENT";
+	orig_type[22]="DRIV";   orig_type[23]="DRV";    orig_type[24]="DR";
+	orig_type[25]="DRIVE";  orig_type[26]="EXP";    orig_type[27]="EXPR";
+	orig_type[28]="EXPRESS";orig_type[29]="EXPW";   orig_type[30]="EXPY";
+	orig_type[31]="EXPRESSWAY"; orig_type[32]="GRN";orig_type[33]="KEY";
+	orig_type[34]="KYS";    orig_type[35]="KY";     orig_type[36]="LA";
+	orig_type[37]="LN";     orig_type[38]="LANE";   orig_type[39]="MDW";
+	orig_type[40]="MDWS";   orig_type[41]="MEADOWS";orig_type[42]="MEADOW";
+	orig_type[43]="MEWS";   orig_type[44]="PKWY";   orig_type[45]="PARKWAYS";
+	orig_type[46]="PARKWY"; orig_type[47]="PARKWAY";orig_type[48]="PL";
+	orig_type[49]="PLZA";   orig_type[50]="PLZ";    orig_type[51]="PLAZA";
+	orig_type[52]="PROM";   orig_type[53]="PRMNDE"; orig_type[54]="PROMENADE";
+	orig_type[55]="RD";     orig_type[56]="SQUARES";orig_type[57]="SQR";
+	orig_type[58]="SQRE";   orig_type[59]="SQRS";   orig_type[60]="SQU";
+	orig_type[61]="SQUARE"; orig_type[62]="ST";     orig_type[63]="TER";
+	orig_type[64]="TERR";   orig_type[65]="TERRACE";orig_type[66]="WALKS";
+	orig_type[67]="WALK";   orig_type[68]="WAY";    orig_type[69]="WY";
+
+	array new_type[69] $ _temporary_;
+
+	new_type[1]="ALLEY";   new_type[2]="ALLEY";   new_type[3]="ALLEY";
+	new_type[4]="ALLEY";   new_type[5]="ALLEY";   new_type[6]="AVENUE";
+	new_type[7]="AVENUE";  new_type[8]="AVENUE";  new_type[9]="AVENUE";
+	new_type[10]="AVENUE"; new_type[11]="AVENUE"; new_type[12]="BOULEVARD";
+	new_type[13]="BOULEVARD"; new_type[14]="BOULEVARD"; new_type[15]="CIRCLE";
+	new_type[16]="CIRCLE"; new_type[17]="CIRCLE"; new_type[18]="COURT";
+	new_type[19]="COURT";  new_type[20]="CRESCENT"; new_type[21]="CRESCENT";
+	new_type[22]="DRIVE";  new_type[23]="DRIVE";  new_type[24]="DRIVE";
+	new_type[25]="DRIVE";  new_type[26]="EXPRESSWAY"; new_type[27]="EXPRESSWAY";
+	new_type[28]="EXPRESSWAY"; new_type[29]="EXPRESSWAY"; new_type[30]="EXPRESSWAY";
+	new_type[31]="EXPRESSWAY"; new_type[32]="GREEN"; new_type[33]="KEYS";
+	new_type[34]="KEYS";   new_type[35]="KEYS";   new_type[36]="LANE";
+	new_type[37]="LANE";   new_type[38]="LANE";   new_type[39]="MEADOW";
+	new_type[40]="MEADOWS";new_type[41]="MEADOWS";new_type[42]="MEADOW";
+	new_type[43]="MEADOWS";new_type[44]="PARKWAY";new_type[45]="PARKWAY";
+	new_type[46]="PARKWAY";new_type[47]="PARKWAY";new_type[48]="PLACE";
+	new_type[49]="PLAZA";  new_type[50]="PLAZA";  new_type[51]="PLAZA";
+	new_type[52]="PROMENADE"; new_type[53]="PROMENADE"; new_type[54]="PROMENADE";
+	new_type[55]="ROAD";   new_type[56]="SQUARE"; new_type[57]="SQUARE";
+	new_type[58]="SQUARE"; new_type[59]="SQUARE"; new_type[60]="SQUARE";
+	new_type[61]="SQUARE"; new_type[62]="STREET"; new_type[63]="TERRACE";
+	new_type[64]="TERRACE";new_type[65]="TERRACE";new_type[66]="WALK";
+	new_type[67]="WALK";   new_type[68]="WAY";    new_type[69]="WAY";
+
+	array old_dir[69] $ _temporary_;
+	array new_dir[69] $ _temporary_;
+
+	old_dir[1]="NORTHEAST"; old_dir[2]="N.E."; old_dir[3]="SOUTHEAST";
+	old_dir[4]="S.E."; old_dir[5]="SOUTHWEST"; old_dir[6]="S.W.";
+	old_dir[7]="NORTHWEST"; old_dir[8]="N.W."; old_dir[9]="NW";
+	old_dir[10]="NE"; old_dir[11]="SW"; old_dir[12]="SE";
+
+	new_dir[1]="NE"; new_dir[2]="NE"; new_dir[3]="SE";
+	new_dir[4]="SE"; new_dir[5]="SW"; new_dir[6]="SW";
+	new_dir[7]="NW"; new_dir[8]="NW"; new_dir[9]="NW";
+	new_dir[10]="NE"; new_dir[11]="SW"; new_dir[12]="SE";
+
+%mend set_street_arrays;
+
+/* Mock raw addresses (the geocoder reads parsed DC address parts).
+   Pipe-delimited so multi-word street names stay intact and the raw type
+   token is preserved exactly. */
+data raw_addr;
+  length raw_street $ 30 raw_type $ 12;
+  infile datalines dsd dlm='|';
+  input raw_street $ raw_type $;
+  datalines;
+14TH|ST
+PENNSYLVANIA|AVE
+MARTIN LUTHER KING|AV
+RHODE ISLAND|PKWY
+GOOD HOPE|RD
+NEBRASKA|CIR
+;
+run;
+
+/* Standardize the street type using the orig_type/new_type arrays. */
+data std_addr;
+  set raw_addr;
+  %set_street_arrays()
+
+  length std_type $ 12;
+  std_type = raw_type;               /* default: leave as-is if no match */
+  do _k = 1 to dim( orig_type );
+    if upcase( raw_type ) = orig_type[_k] then do;
+      std_type = new_type[_k];
+      leave;
+    end;
+  end;
+  drop _k;
+run;
+
+proc print data=std_addr label noobs;
+  var raw_street raw_type std_type;
+  label raw_street = "Street name" raw_type = "Raw type"
+        std_type = "Standardized type";
+  title "DC street types standardized with RealProp %set_street_arrays";
+run;


### PR DESCRIPTION
[Jenneranalytics.com](https://jenneranalytics.com) provides an API that runs SAS code, with support for more than 200 SAS procedures. You can also use it with Anthropic Claude Code AI in a collaborative workspace. It's available for Mac on the Apple App Store, and by license for Windows and Linux. Your RealProp autocall macros run on it unmodified — this PR adds a few compatibility bundles so you can see for yourself.

It adds a `jenner-check/` directory with three self-contained bundles, each built from one of your `Macros/` autocall macros and paired with small sample data so it runs in isolation:

```
jenner-check/
├── t001_macro_max_afford_price/    %max_afford_price() over income scenarios
├── t002_macro_ownername_full/      %Ownername_full() combining owner names
├── t003_macro_set_street_arrays/   %set_street_arrays() standardizing street types
└── run_jenner.sh / .bat / .sas     one runner for all bundles
```

To run them, use the included pure-SAS runner (`cd jenner-check && ./run_jenner.sh --all`) or paste any bundle's `script.sas` into the hosted workspace. Each bundle ships an `expected/` snapshot of the log and listing it produced.

The autocall library here is a pleasure to read — every macro opens with a clear header documenting its purpose, version history, and the variables it expects. `%max_afford_price()` is a tidy example, exposing each mortgage assumption as a defaulted keyword parameter so one call yields an affordability estimate.

No response is needed — merge, close, or ignore as you see fit. To opt out of future messages like this, reply `no-more-prs` in a comment or open an issue titled `jenner-check: opt out`.

---

Lawrence W. Sinclair  
CEO / Jenner Analytics Ltd  
[jenneranalytics.com](https://jenneranalytics.com)  
[linkedin.com/in/lwsinclair/](https://www.linkedin.com/in/lwsinclair/)
